### PR TITLE
DM-30699: Add new flux measurement to meas_extensions_trailedSources

### DIFF
--- a/include/lsst/meas/extensions/trailedSources/VeresModel.h
+++ b/include/lsst/meas/extensions/trailedSources/VeresModel.h
@@ -95,6 +95,9 @@ public:
      */
     std::vector<double> gradient(std::vector<double> const& params) const;
 
+    /// Compute an image for a trail generated from the Veres model.
+    std::shared_ptr<ImageF> computeModelImage(std::vector<double> const& params) const;
+
     /// Return the PSF sigma.
     double getSigma() const noexcept { return _sigma; }
 

--- a/python/lsst/meas/extensions/trailedSources/VeresPlugin.py
+++ b/python/lsst/meas/extensions/trailedSources/VeresPlugin.py
@@ -33,6 +33,7 @@ from lsst.meas.base import MeasurementError
 
 from ._trailedSources import VeresModel
 from .NaivePlugin import SingleFrameNaiveTrailPlugin
+from .utils import getMeasurementCutout
 
 __all__ = ("SingleFrameVeresTrailConfig", "SingleFrameVeresTrailPlugin")
 
@@ -142,8 +143,13 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
         if not np.isfinite(F) or not np.isfinite(L) or not np.isfinite(theta):
             raise MeasurementError(self.NO_NAIVE.doc, self.NO_NAIVE.number)
 
+        # Get exposure cutout
+        # sigma = exposure.getPsf().getSigma()
+        # cutout = getMeasurementCutout(exposure, xc, yc, L, sigma)
+        cutout = getMeasurementCutout(measRecord, exposure)
+
         # Make VeresModel
-        model = VeresModel(exposure)
+        model = VeresModel(cutout)
 
         # Do optimization with scipy
         params = np.array([xc, yc, F, L, theta])
@@ -161,7 +167,7 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
         y0_fit = yc_fit - a * np.sin(theta_fit)
         x1_fit = xc_fit + a * np.cos(theta_fit)
         y1_fit = yc_fit + a * np.sin(theta_fit)
-        rChiSq = results.fun / (exposure.image.array.size - 6)
+        rChiSq = results.fun / (cutout.image.array.size - 6)
 
         # Set keys
         measRecord.set(self.keyXC, xc_fit)

--- a/python/lsst/meas/extensions/trailedSources/VeresPlugin.py
+++ b/python/lsst/meas/extensions/trailedSources/VeresPlugin.py
@@ -106,7 +106,7 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
         self.keyY0 = schema.addField(name + "_y0", type="D", doc="Trail head Y coordinate.", units="pixel")
         self.keyX1 = schema.addField(name + "_x1", type="D", doc="Trail tail X coordinate.", units="pixel")
         self.keyY1 = schema.addField(name + "_y1", type="D", doc="Trail tail Y coordinate.", units="pixel")
-        self.keyL = schema.addField(name + "_length", type="D", doc="Length of trail.", units="pixel")
+        self.keyLength = schema.addField(name + "_length", type="D", doc="Length of trail.", units="pixel")
         self.keyTheta = schema.addField(name + "_angle", type="D", doc="Angle of trail from +x-axis.")
         self.keyFlux = schema.addField(name + "_flux", type="D", doc="Trailed source flux.", units="count")
         self.keyRChiSq = schema.addField(name + "_rChiSq", type="D", doc="Reduced chi-squared of fit")
@@ -137,22 +137,22 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
 
         # Look at measRecord for Naive measurements
         # ASSUMES NAIVE ALREADY RAN
-        F = measRecord.get("ext_trailedSources_Naive_flux")
-        L = measRecord.get("ext_trailedSources_Naive_length")
+        flux = measRecord.get("ext_trailedSources_Naive_flux")
+        length = measRecord.get("ext_trailedSources_Naive_length")
         theta = measRecord.get("ext_trailedSources_Naive_angle")
-        if not np.isfinite(F) or not np.isfinite(L) or not np.isfinite(theta):
+        if not np.isfinite(flux) or not np.isfinite(length) or not np.isfinite(theta):
             raise MeasurementError(self.NO_NAIVE.doc, self.NO_NAIVE.number)
 
         # Get exposure cutout
         # sigma = exposure.getPsf().getSigma()
-        # cutout = getMeasurementCutout(exposure, xc, yc, L, sigma)
+        # cutout = getMeasurementCutout(exposure, xc, yc, length, sigma)
         cutout = getMeasurementCutout(measRecord, exposure)
 
         # Make VeresModel
         model = VeresModel(cutout)
 
         # Do optimization with scipy
-        params = np.array([xc, yc, F, L, theta])
+        params = np.array([xc, yc, flux, length, theta])
         results = sciOpt.minimize(
             model, params, method=self.config.optimizerMethod, jac=model.gradient)
 
@@ -161,8 +161,8 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
             raise MeasurementError(self.NON_CONVERGE.doc, self.NON_CONVERGE.number)
 
         # Calculate end points and reduced chi-squared
-        xc_fit, yc_fit, F_fit, L_fit, theta_fit = results.x
-        a = L_fit/2
+        xc_fit, yc_fit, flux_fit, length_fit, theta_fit = results.x
+        a = length_fit/2
         x0_fit = xc_fit - a * np.cos(theta_fit)
         y0_fit = yc_fit - a * np.sin(theta_fit)
         x1_fit = xc_fit + a * np.cos(theta_fit)
@@ -176,8 +176,8 @@ class SingleFrameVeresTrailPlugin(SingleFramePlugin):
         measRecord.set(self.keyY0, y0_fit)
         measRecord.set(self.keyX1, x1_fit)
         measRecord.set(self.keyY1, y1_fit)
-        measRecord.set(self.keyFlux, F_fit)
-        measRecord.set(self.keyL, L_fit)
+        measRecord.set(self.keyFlux, flux_fit)
+        measRecord.set(self.keyLength, length_fit)
         measRecord.set(self.keyTheta, theta_fit)
         measRecord.set(self.keyRChiSq, rChiSq)
 

--- a/python/lsst/meas/extensions/trailedSources/_VeresModel.cc
+++ b/python/lsst/meas/extensions/trailedSources/_VeresModel.cc
@@ -49,6 +49,7 @@ void wrapVeresModel(utils::python::WrapperCollection& wrappers) {
             cls.def(py::init<afw::image::Exposure<float> const&>(), "data"_a);
             cls.def("__call__", &VeresModel::operator(), py::is_operator(), "params"_a);
             cls.def("gradient", &VeresModel::gradient, "params"_a);
+            cls.def("computeModelImage", &VeresModel::computeModelImage, "params"_a);
             cls.def_property_readonly("sigma", &VeresModel::getSigma);
     });
 }

--- a/python/lsst/meas/extensions/trailedSources/utils.py
+++ b/python/lsst/meas/extensions/trailedSources/utils.py
@@ -1,0 +1,36 @@
+#
+# This file is part of meas_extensions_trailedSources.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Common functions for trail measurements
+__all__ = ("getMeasurementCutout")
+
+
+def getMeasurementCutout(measRecord, exposure):
+    """Get a subImage cutout for a trail measurement.
+
+    Re-implements meas::base::SdssShape::computeAdaptiveMomentsBBox
+    """
+    bbox = measRecord.getFootprint().getBBox()
+    bbox.clip(exposure.getBBox())
+    cutout = exposure.Factory(exposure, bbox)
+    return cutout

--- a/src/VeresModel.cc
+++ b/src/VeresModel.cc
@@ -92,6 +92,25 @@ std::vector<double> VeresModel::gradient(std::vector<double> const& params) cons
     return gradChiSq;
 }
 
+std::shared_ptr<ImageF> VeresModel::computeModelImage(std::vector<double> const& params) const {
+    double xc = params[0];     // Centroid x
+    double yc = params[1];     // Centroid y
+    double flux = params[2];   // Flux
+    double length = params[3]; // Trail length
+    double theta = params[4];  // Angle from +x-axis
+
+    // Loop is adapted from lsst::afw::detection::GaussianPsf::doComputeKernelImage()
+    std::shared_ptr<ImageF> image(new ImageF(_bbox));
+    ImageF::Array array = image->getArray();
+    for (int yIndex = 0, yp = _bbox.getBeginY(); yIndex < _bbox.getHeight(); ++yIndex, ++yp) {
+        ImageF::Array::Reference row = array[yIndex];
+        for (int xIndex = 0, xp = _bbox.getBeginX(); xIndex < _bbox.getWidth(); ++xIndex, ++xp) {
+            row[xIndex] = _computeModel(xp,yp,xc,yc,flux,length,theta);
+        }
+    }
+    return image;
+}
+
 double VeresModel::_computeModel(double x, double y, double xc, double yc,
                                  double flux, double length, double theta) const noexcept {
     double xp = (x-xc)*cos(theta) + (y-yc)*sin(theta);


### PR DESCRIPTION
- Add a measurement of flux to `NaivePlugin`. 
- Add method that returns a model image to `VereModel`.
- Update `VeresPlugin` to compute model over exposure cutout rather than full exposure.
- Add `utils.py` for common functions. Currently holds a function to return exposure cutouts. 
- Replace instances of single letter variables (ie. L, F, etc.) with more descriptive names (length, flux, etc.).