### PR TITLE
DM-33325: Update measurement uncertainties in meas_extensions_trailedSources

### DIFF
--- a/include/lsst/meas/extensions/trailedSources/VeresModel.h
+++ b/include/lsst/meas/extensions/trailedSources/VeresModel.h
@@ -95,6 +95,26 @@ public:
      */
     std::vector<double> gradient(std::vector<double> const& params) const;
 
+    /**
+     * Computes the flux and the gradient with respect to the other model parameters.
+     *
+     * We estimate the flux by solving the linear least-squares problem for the
+     * Veres et al. 2012 model. By keeping the length, angle, and centroid
+     * coordinates fixed, we analytically solve for the flux.
+     *
+     * @param params Model parameters.
+     *
+     * @return The flux and the gradient with respect to the model parameters.
+     *
+     * @note The params vector contains the following model parameters:
+     *     - Centroid x: X-coordinate of the centroid in given image [pixels].
+     *     - Centroid y: Y-coordinate of the centroid in given image [pixels].
+     *     - Flux: Total flux in the trail [count].
+     *     - Length: Length of the trail [pixels].
+     *     - Angle: Angle from the +x-axis [radians].
+     */
+    std::tuple<double, std::vector<double>> computeFluxWithGradient(std::vector<double> const& params) const;
+
     /// Compute an image for a trail generated from the Veres model.
     std::shared_ptr<ImageF> computeModelImage(std::vector<double> const& params) const;
 

--- a/python/lsst/meas/extensions/trailedSources/_VeresModel.cc
+++ b/python/lsst/meas/extensions/trailedSources/_VeresModel.cc
@@ -49,6 +49,7 @@ void wrapVeresModel(utils::python::WrapperCollection& wrappers) {
             cls.def(py::init<afw::image::Exposure<float> const&>(), "data"_a);
             cls.def("__call__", &VeresModel::operator(), py::is_operator(), "params"_a);
             cls.def("gradient", &VeresModel::gradient, "params"_a);
+            cls.def("computeFluxWithGradient", &VeresModel::computeFluxWithGradient, "params"_a);
             cls.def("computeModelImage", &VeresModel::computeModelImage, "params"_a);
             cls.def_property_readonly("sigma", &VeresModel::getSigma);
     });

--- a/tests/test_trailedSources.py
+++ b/tests/test_trailedSources.py
@@ -25,7 +25,11 @@ import numpy as np
 import unittest
 import lsst.utils.tests
 import lsst.meas.extensions.trailedSources
+from scipy.optimize import check_grad
 from lsst.meas.base.tests import AlgorithmTestCase
+from lsst.meas.extensions.trailedSources import SingleFrameNaiveTrailPlugin as sfntp
+from lsst.meas.extensions.trailedSources import VeresModel
+from lsst.meas.extensions.trailedSources.utils import getMeasurementCutout
 from lsst.utils.tests import classParameters
 
 import lsst.log
@@ -120,6 +124,49 @@ class TrailedSourcesTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         del self.trail
         del self.dataset
 
+    @staticmethod
+    def transformMoments(Ixx, Iyy, Ixy):
+        """Transform second-moments to semi-major and minor axis.
+        """
+        xmy = Ixx - Iyy
+        xpy = Ixx + Iyy
+        xmy2 = xmy*xmy
+        xy2 = Ixy*Ixy
+        a2 = 0.5 * (xpy + np.sqrt(xmy2 + 4.0*xy2))
+        b2 = 0.5 * (xpy - np.sqrt(xmy2 + 4.0*xy2))
+        return a2, b2
+
+    @staticmethod
+    def f_length(x):
+        return sfntp.findLength(*x)[0]
+
+    @staticmethod
+    def g_length(x):
+        return sfntp.findLength(*x)[1]
+
+    @staticmethod
+    def f_flux(x, model):
+        return model.computeFluxWithGradient(x)[0]
+
+    @staticmethod
+    def g_flux(x, model):
+        return model.computeFluxWithGradient(x)[1]
+
+    @staticmethod
+    def central_difference(func, x, *args, h=1e-8):
+        result = np.zeros(len(x))
+        for i in range(len(x)):
+            xp = x.copy()
+            xp[i] += h
+            fp = func(xp, *args)
+
+            xm = x.copy()
+            xm[i] -= h
+            fm = func(xm, *args)
+            result[i] = (fp - fm) / (2*h)
+
+        return result
+
     def makeTrailedSourceMeasurementTask(self, plugin=None, dependencies=(),
                                          config=None, schema=None, algMetadata=None):
         """Set up a measurement task for a trailed source plugin.
@@ -175,6 +222,22 @@ class TrailedSourcesTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
                                      atol=np.arctan(1/length), rtol=None)
         self.assertFloatsAlmostEqual(flux, self.trail.instFlux, atol=None, rtol=0.1)
 
+        # Test function gradients versus finite difference derivatives
+        # Do length first
+        Ixx, Iyy, Ixy = record.getShape().getParameterVector()
+        a2, b2 = self.transformMoments(Ixx, Iyy, Ixy)
+        self.assertLessEqual(check_grad(self.f_length, self.g_length, [a2, b2]), 1e-6)
+
+        # Now flux gradient
+        xc = record.get("base_SdssShape_x")
+        yc = record.get("base_SdssShape_y")
+        params = np.array([xc, yc, 1.0, length, theta])
+        cutout = getMeasurementCutout(record, exposure)
+        model = VeresModel(cutout)
+        gradNum = self.central_difference(self.f_flux, params, model, h=9e-5)
+        gradMax = np.max(np.abs(gradNum - self.g_flux(params, model)))
+        self.assertLessEqual(gradMax, 1e-5)
+
         # Check test setup
         self.assertNotEqual(length, self.trail.length)
         self.assertNotEqual(theta, self.trail.angle)
@@ -213,6 +276,15 @@ class TrailedSourcesTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(theta % np.pi, self.trail.angle % np.pi,
                                      atol=np.arctan(1/length), rtol=None)
         self.assertFloatsAlmostEqual(flux, self.trail.instFlux, atol=None, rtol=0.1)
+
+        xc = record.get("ext_trailedSources_Veres_centroid_x")
+        yc = record.get("ext_trailedSources_Veres_centroid_y")
+        params = np.array([xc, yc, flux, length, theta])
+        cutout = getMeasurementCutout(record, exposure)
+        model = VeresModel(cutout)
+        gradNum = self.central_difference(model, params, h=1e-6)
+        gradMax = np.max(np.abs(gradNum - model.gradient(params)))
+        self.assertLessEqual(gradMax, 1e-5)
 
         # Make sure test setup is working as expected
         self.assertNotEqual(length, self.trail.length)


### PR DESCRIPTION
First-pass at adding uncertainties for updated `NaivePlugin` measurements (length, angle, flux).
- Move flux computation to C++ layer, and adds gradient computation with respect to the other `VeresModel` parameters.
- Add `SAFE_CENTROID` flag. (Want the `SdssShape` centroid, so throw flag if we fall back to safe.)
- Move 'non-weighted' length computation to function and compute gradients of both length computations.
- Propagate measurement uncertainties from centroid and second-moments.
- Add tests for gradient computations
- Add monte-carlo tests for length and angle uncertainties. For now, just make sure we're close, or at least over estimate. 

Note: Flux uncertainty underestimates the monte-carlo derived values (often ~50%). This will be addressed in a future PR. 