### PR TITLE
DM-43974: Fix errors in ext_trailedSources_Naive

### DIFF
--- a/python/lsst/meas/extensions/trailedSources/NaivePlugin.py
+++ b/python/lsst/meas/extensions/trailedSources/NaivePlugin.py
@@ -127,7 +127,7 @@ class SingleFrameNaiveTrailPlugin(SingleFramePlugin):
         self.EDGE = flagDefs.add("flag_edge", "Trail contains edge pixels or extends off chip")
         self.flagHandler = FlagHandler.addFields(schema, name, flagDefs)
 
-        self.centriodExtractor = SafeCentroidExtractor(schema, name)
+        self.centroidExtractor = SafeCentroidExtractor(schema, name)
         self.log = logging.getLogger(self.logName)
 
     def measure(self, measRecord, exposure):


### PR DESCRIPTION
Fixed typo in `ext_trailedSources_Naive `where `centroidExtractor` was misspelled and thus was not implemented.

Added a check of the second moment which would fail if nans were present. Nans present in the second moment are now logged and now returns instead of continuing.